### PR TITLE
mali: Enable GPU use timers

### DIFF
--- a/drivers/gpu/arm/mali4_64/r6p0-01rel0/common/mali_control_timer.c
+++ b/drivers/gpu/arm/mali4_64/r6p0-01rel0/common/mali_control_timer.c
@@ -45,7 +45,7 @@ static void mali_control_timer_callback(void *arg)
 			mali_utilization_platform_realize(util_data);
 #endif
 
-			if ((MALI_TRUE == need_add_timer) && (0 != util_data->utilization_gpu)) {
+			if (MALI_TRUE == need_add_timer) {
 				mali_control_timer_add(mali_control_timeout);
 			}
 		}


### PR DESCRIPTION
* There was a bug were the timer stopped counting if GPU use reached 0.